### PR TITLE
ButtonGroupFormField添加对子元素合法性的检测，忽略不合法的children项，并对不规范的使用添加部分警告信息

### DIFF
--- a/src/FormField/ButtonGroupFormField.js
+++ b/src/FormField/ButtonGroupFormField.js
@@ -38,7 +38,7 @@ class ButtonGroupFormField extends React.Component {
 
                     //警告断言, 在uxcore-form外直接使用时,不能正常工作,这里给出警告信息
                     if(!me.props.resetValues || typeof me.props.resetValues !== 'function') {
-                        console.warn('resetValues method missing, the reset button will work incorrectly');
+                        console.warn('resetValues method missing, the reset button will works incorrectly');
                     }
 
                     props.onClick = () => {


### PR DESCRIPTION
1.  添加子元素的合法性判断，使ButtonGroupFormField支持如下的代码写法：  
   
   ```
   let childButton;
   if(condition) {
   childButton = <Button>...</Button>
   }
   
   //当前rep的代码，当condition为false时，会导致ButtonGroupFormField的_processChild报错，表示child不能接受null或undefined。
   return <ButtonGroupFormField>
   {childButton}
   </ButtonGroupFormField>
   
   ```
2.  添加部分断言警告内容，当此组件没有被正确使用时，给予适当提示信息，如下：
   
   ```
   if(!me.props.getValues || typeof me.props.getValues !== 'function') {
   console.warn("getValues method missing, the submit button will works incorrectly");
   }
   
   props.onClick = () => {
   let data = me.props.getValues();
   child.props.onClick(data)
   }
   ```
