### PR TITLE
fix bug for _processChild

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -144,7 +144,7 @@ class Form extends React.Component {
 
         React.Children.forEach(children, function(child, index) {
             // 如果是自己添加的 DOM 直接抛弃
-            if (typeof child.type == 'function') {
+            if (child && typeof child.type == 'function') {
                 let displayName = child.type.displayName;
                 if (displayName === 'EngineNode') {
                     displayName = child.props._componentName;


### PR DESCRIPTION
Form 表单下面有一种使用场景：

``` javascript
<Form>
{
          this.props.type === 'image'
            ?
            <UploaderFormField
              jsxname="upload-file"
              jsxlabel="公告图片"
              required={true}
              jsxrules={[
                {validator: Validators.isNotEmpty, errMsg: "不能为空"},
              ]}
              autoPending={false}
              multiple={false}
              isOnlyImg={false}
              fileList={this.state.fileList}
              onChange={this.onUploaderChange.bind(this)}
              name='file'
              url='http://eternalsky.me:8122/file/upload'
              locale="en">
              <Button size="medium" type="secondary">上传公告图片</Button>
            </UploaderFormField>
            :
            null
        }
</Form>
```

在 Form.js _processChild 方法中判断 Children 时，针对返回的 null，判断报错。
